### PR TITLE
Add sphinxcontrib.cairosvgconverter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,10 @@ Sphinx SVG to PDF Converter Extension
 This extension converts SVG images to PDF in case the builder does not support
 SVG images natively (e.g. LaTeX).
 
-Internally, either `Inkscape <https://inkscape.org/>`_ or ``rsvg-convert`` from
-`libRSVG <https://wiki.gnome.org/Projects/LibRsvg>`_ as a more lightweight
-alternative is used to convert images.
+Internally, either `Inkscape <https://inkscape.org/>`_, ``rsvg-convert``
+from `libRSVG <https://wiki.gnome.org/Projects/LibRsvg>`_ or `CairoSVG
+<https://cairosvg.org/>`_ as progressively more lightweight alternatives
+are used to convert images.
 
 
 Installation
@@ -19,14 +20,24 @@ Just install via ``pip``:
 
    $ pip install sphinxcontrib-svg2pdfconverter
 
-You can choose between Inkscape and libRSVG by either adding
-``sphinxcontrib.inkscapeconverter`` or ``sphinxcontrib.rsvgconverter`` to the
-``extensions`` list in your ``conf.py``.
+You can choose between Inkscape, libRSVG and CairoSVG by adding
+``sphinxcontrib.inkscapeconverter``, ``sphinxcontrib.rsvgconverter`` or
+``sphinxcontrib.cairosvgconverter`` to the ``extensions`` list in your
+``conf.py``.
 
 Make sure to have either ``inkscape`` or the ``rsvg-convert`` command available
 in your systems ``PATH`` and, if necessary, adapt the
 ``inkscape_converter_bin`` or ``rsvg_converter_bin`` config value respectively.
 
+``CairoSVG`` has extra dependency requiring install with ``CairoSVG`` extra:
+
+.. code-block:: console
+
+   $ pip install sphinxcontrib-svg2pdfconverter[CairoSVG]
+
+It also needs native libraries that must be installed according to
+operating system used. See the `CairoSVG documentation
+<https://cairosvg.org/documentation/>`_ for details.
 
 Configuration
 =============
@@ -50,3 +61,8 @@ RSVG
 ``rsvg_converter_args``
     Additional command-line arguments for the RSVG converter, as a list. By
     default, this is the emtpy list ``[]``.
+
+CairoSVG
+--------
+
+No configuration is required.

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=requires,
+    extras_require={
+        "CairoSVG": ['cairosvg>=1.0'],
+    },
     python_requires='~=3.4',
     namespace_packages=['sphinxcontrib'],
 )

--- a/sphinxcontrib/cairosvgconverter.py
+++ b/sphinxcontrib/cairosvgconverter.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""
+    sphinxcontrib.cairosvgconverter
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Converts SVG images to PDF using CairoSVG in case the builder does not
+    support SVG images natively (e.g. LaTeX).
+
+    See <https://cairosvg.org/>.
+
+    :copyright: Copyright 2018-2020 by Stefan Wiehler
+                <stefan.wiehler@missinglinkelectronics.com> and
+                Copyright 2020 by Marko Kohtala
+                <marko.kohtala@gmail.com>.
+    :license: BSD, see LICENSE.txt for details.
+"""
+
+from sphinx.errors import ExtensionError
+from sphinx.locale import __
+from sphinx.transforms.post_transforms.images import ImageConverter
+from sphinx.util import logging
+from urllib.error import URLError
+
+if False:
+    # For type annotation
+    from typing import Any, Dict  # NOQA
+    from sphinx.application import Sphinx  # NOQA
+
+
+logger = logging.getLogger(__name__)
+
+
+class CairoSVGConverter(ImageConverter):
+    conversion_rules = [
+        ('image/svg+xml', 'application/pdf'),
+    ]
+
+    def is_available(self):
+        # type: () -> bool
+        """Confirms if CairoSVG converter is available or not."""
+        try:
+            import cairosvg  # noqa: F401
+            return True
+        except (OSError, IOError, ImportError):
+            logger.warning(__('CairoSVG converter cannot be imported. '
+                              'Check you have cairosvg and libcairo-2 installed'))
+            return False
+
+    def convert(self, _from, _to):
+        # type: (unicode, unicode) -> bool
+        """Converts the image from SVG to PDF via CairoSVG."""
+        import cairosvg
+        try:
+            cairosvg.svg2pdf(url=_from, write_to=_to)
+        except URLError as err:
+            raise ExtensionError(__('CairoSVG converter exited with reason:\n'
+                                    '%s') % err.reason)
+
+        return True
+
+
+def setup(app):
+    # type: (Sphinx) -> Dict[unicode, Any]
+    app.add_post_transform(CairoSVGConverter)
+
+    return {
+        'version': 'builtin',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }


### PR DESCRIPTION
I found there is a lightweight [cairosvg](https://pypi.org/project/CairoSVG/) package for Python for SVG to PDF conversion.

This adds a module to use it for conversion.

I have a large activity diagram created with PlantUML. Currently on Ubuntu 18.04.4 LTS I get strangely scaled images with inkscape, rsvg-converter makes it huge and very slow (although other tools keep it small and fast). CairoSVG is fast, but unfortunately the diagrams don't have all lines in correct places. But CairoSVG is under active maintenance, so that may improve over time. I request adding support for it as an alternative to the others.