### PR TITLE
Fix CairSVGConverter::convert for usage on Windows

### DIFF
--- a/sphinxcontrib/cairosvgconverter.py
+++ b/sphinxcontrib/cairosvgconverter.py
@@ -51,7 +51,7 @@ class CairoSVGConverter(ImageConverter):
         """Converts the image from SVG to PDF via CairoSVG."""
         import cairosvg
         try:
-            cairosvg.svg2pdf(url=_from, write_to=_to)
+            cairosvg.svg2pdf(file_obj=open(_from, 'rb'), write_to=_to)
         except (OSError, URLError) as err:
             raise ExtensionError(__('CairoSVG converter failed with reason: '
                                     '%s') % err.reason)


### PR DESCRIPTION
Update the convert method of the CairoSVGConverter class to use an
alternative call signature for cairosvg.svg2pdf. It now uses the
file_obj call signature rather than the url signature. The previous
signature requires elevated priveleges on Windows.