### PR TITLE
add minimal pyproject.toml, use stdlib for pep420

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/sphinxcontrib/__init__.py
+++ b/sphinxcontrib/__init__.py
@@ -10,5 +10,4 @@
     :license: BSD, see LICENSE.txt for details.
 """
 
-__import__('pkg_resources').declare_namespace(__name__)
-
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
Thanks for this tool!

This PR adds some minor metadata to the repo to reduce downstream warnings when building from source which will probably become failures within the next year. While `setuptools` _is_ a build-time dependency, this updates to using `pkgutil.extend_path` to align the [PEP420 guidance](https://peps.python.org/pep-0420/#namespace-packages-today).

<details>

<summary>Motivation...</summary>

These changes were suggested while building/testing downstream on [conda-forge](https://github.com/conda-forge/sphinxcontrib-svg2pdfconverter-feedstock). This will get mostly-automated updates when new `sdist`s show up on PyPI, so no work will be required on this side. 

However, users (especially on proprietary platforms) may find the `conda-forge` option compelling, as this ecosystem is fairly widely supported on GitHub, ReadTheDocs and other places where documentation sites are often built.

With `conda` (or `mamba`, `micromamba` or `pixi`) on linux, macos[-arm64], or windows:

```bash
conda install -c conda-forge sphinxcontrib-svg2pdfconverter 
```

While the above tools _don't_ support PyPI `[extras]` directly, two of the backends _are_ supported by name:

```bash
conda install -c conda-forge sphinxcontrib-svg2pdfconverter-with-rsvg
conda install -c conda-forge sphinxcontrib-svg2pdfconverter-with-cairosvg
```

There is  no `-with-inkscape`, as `conda-forge` has only an old windows binary blob of `inkscape 0.91`, but it did at least pass the [smoke tests](https://github.com/conda-forge/sphinxcontrib-svg2pdfconverter-feedstock/blob/main/recipe/converter_test.py) on windows, and locally against an externally-managed `inkscape`. Future versions will only be tested on linux-64.

Thanks again!