### PR TITLE
add rsvg_converter_format config option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,11 @@ RSVG
 ``rsvg_converter_bin``
     Path to RSVG converter binary. By default, this is ``rsvg-convert``.
 
+``rsvg_converter_format``
+    The value provided to the RSVG converter's ``--format`` argument. In more
+    recent RSVG builds, the ``pdf1.5`` format will generate the fewest warnings
+    with LaTeX backends. By default, this is ``pdf``.
+
 ``rsvg_converter_args``
     Additional command-line arguments for the RSVG converter, as a list. By
     default, this is the empty list ``[]``.

--- a/sphinxcontrib/rsvgconverter.py
+++ b/sphinxcontrib/rsvgconverter.py
@@ -55,7 +55,8 @@ class RSVGConverter(ImageConverter):
         try:
             args = ([self.config.rsvg_converter_bin] +
                     self.config.rsvg_converter_args +
-                    ['--format=pdf', '--output=' + _to, _from])
+                    ['--format=' + self.config.rsvg_converter_format,
+                     '--output=' + _to, _from])
             logger.debug('Invoking %r ...', args)
             p = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
         except OSError as err:
@@ -86,6 +87,7 @@ def setup(app):
     app.add_post_transform(RSVGConverter)
     app.add_config_value('rsvg_converter_bin', 'rsvg-convert', 'env')
     app.add_config_value('rsvg_converter_args', [], 'env')
+    app.add_config_value('rsvg_converter_format', 'pdf', 'env')
 
     return {
         'version': 'builtin',


### PR DESCRIPTION
Thanks again for this tool.

In the never-ending quest to get fewer LaTeX warnings, I tried adding:

```python
# conf.py
rsvg_converter_args = ["--format=pdf1.5"]
```

... but `--format=pdf` is already present, which causes a failure. This PR adds an explicit configuration option, defaulting to `pdf`, and some documentation noting the `pdf1.5` option