### PR TITLE
Revert "add minimal pyproject.toml, use stdlib for pep420"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,0 @@
-[build-system]
-requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta"

--- a/sphinxcontrib/__init__.py
+++ b/sphinxcontrib/__init__.py
@@ -10,4 +10,5 @@
     :license: BSD, see LICENSE.txt for details.
 """
 
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__import__('pkg_resources').declare_namespace(__name__)
+


### PR DESCRIPTION
Reverts missinglinkelectronics/sphinxcontrib-svg2pdfconverter#21

as it currently breaks wheel build.

```
error: Namespace package problem: sphinxcontrib is a namespace package, but its
__init__.py does not call declare_namespace()! Please fix it.
(See the setuptools manual under "Namespace Packages" for details.) 
```

