### PR TITLE
restore minimal PEP517 pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## references
- partially restore #21

## changes
- restore minimal `pyproject.toml`
  - doesn't change the PEP420 approach (still using `pkg_resources`)

## test procedure

```bash
python setup.py bdist_wheel  # works, with warnings
pyproject-build              # works, with warnings
python -m pip install -e .   # works
```

examples of warning:

```
# SetuptoolsDeprecationWarning: setup.py install is deprecated.
# SetuptoolsDeprecationWarning: The namespace_packages parameter is deprecated.
```

## next steps

An alternative PR will propose replacing `setup.(py|cfg)` with `pyproject.toml`, [as per the `setuptools` docs](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html)